### PR TITLE
Add bash version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ VirtualBox VM based on Ubuntu Server.
 
 * Docker >= 18.09.6
 * docker-compose >= 1.24.0
-* GNU Bash
+* GNU Bash >= 4.0
 
 # Install or Update
 


### PR DESCRIPTION
`&>>` operator is not available before bash 4.0.
The bash version installed on *all* OS X versions is 3.2.